### PR TITLE
Don't have "lock" files in package output

### DIFF
--- a/pants_plugins/sendwave/pants_node/package.py
+++ b/pants_plugins/sendwave/pants_node/package.py
@@ -60,7 +60,7 @@ async def get_node_package_file_sources(
     request: NodeSourceFilesRequest,
 ) -> StrippedSourceFiles:
     transitive_targets = await Get(
-        TransitiveTargets, TransitiveTargetsRequest([request.package_address])
+       TransitiveTargets, TransitiveTargetsRequest([request.package_address])
     )
     all_sources = [
         t.get(NodeLibrarySources)
@@ -104,7 +104,6 @@ async def get_node_package_digest(field_set: NodeProjectFieldSet) -> Digest:
         Process(
             argv=[npm_paths.first_path.path, "install"],
             output_directories=["./node_modules"],
-            output_files=["npm-shrinkwrap.json", "./package-lock.json", "yarn.lock"],
             input_digest=build_context.digest,
             env={"PATH": ":".join(search_path)},
             description="installing node project dependencies",


### PR DESCRIPTION
this can cause problems if you already have them in one of the input
digests. We are also relying on people to supply their own
lock file in order to have reproducable builds. So we weren't doing
anythign with this anyway