### PR TITLE
Update sendwave-pants-docker requirement

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 #+EMAIL:       engineering@sendwave.com
 #+DESCRIPTION: Node Plugin Documentation
 
-* Version 1.1.0
+* Version 1.1.1
 
 This package contains a plugin for the [[https://www.pantsbuild.org/][pants build system]] to run npm
 based scripts from pants build targets
@@ -103,6 +103,12 @@ have reproducable builds, you may generate one by running:
 #+END_SRC
 
 * Changelog
+** 1.1.1
+2022-05-27
++ Change Dependency on sendwave-pants-docker from a link hosted on
+  github to a package reference. Which allows _this_ package to be
+  uploaded to pypi. (URL links are not allowed in projects published
+  on pypi)
 ** 1.1.0
 2022-05-27
 + Changes how the build context is constructed

--- a/pants.toml
+++ b/pants.toml
@@ -3,7 +3,7 @@
 pants_version="2.9.0"
 pythonpath = ["%(buildroot)s/pants_plugins"]
 plugins = [
-   "sendwave-pants-docker@https://github.com/waveremit/pants-docker/releases/download/v1.0/sendwave-pants-docker-1.0.tar.gz"
+   "sendwave-pants-docker==1.0",
 ]
 
 backend_packages = [

--- a/pants_plugins/sendwave/pants_node/BUILD
+++ b/pants_plugins/sendwave/pants_node/BUILD
@@ -8,11 +8,12 @@ python_distribution(
     dependencies=[":pants_node_library"],
     provides=setup_py(
         name="sendwave-pants-node",
-        version="1.1.0",
+        version="1.1.1",
         description="Pants Plugin to build node bundles",
-        author="compyman@compyman.net",
+        url="https://github.com/compyman/pants-node",
+        author="Nathan Rosenbloom, Jean Cochrane",
+        author_email="engineering@sendwave.com",
     ),
     sdist=True,
     wheel=True,
-
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sendwave-pants-docker@https://github.com/waveremit/pants-docker/releases/download/v1.0/sendwave-pants-docker-1.0.tar.gz
+sendwave-pants-docker==1.0


### PR DESCRIPTION
Pull sendwave-pants-docker package from pypi, instead of from the
github URL.

This will allow _this_ package to be uploaded to pypi.

Bumps Version to 1.1.1